### PR TITLE
Replaced depreciated endpoint, which fixed the broken "Find Bridge" Function

### DIFF
--- a/package/contents/code/hue.js
+++ b/package/contents/code/hue.js
@@ -2274,7 +2274,7 @@ function getHueIp (callback) {
         }
         callback(false, "");
     }
-    request.open("GET", "https://www.meethue.com/api/nupnp");
+    request.open("GET", "https://discovery.meethue.com");
     request.send();
 }
 


### PR DESCRIPTION
Replaced the older meethue.com/api/nupnp endpoint, as it is depreciated and no longer working.  Replaced the endpoint URL with the CURRENT WORKING endpoint, thus fixing the "Find Bridge" button/action via this plasmoid.